### PR TITLE
Fixed plugin linking bug

### DIFF
--- a/src/ompl_global_planner.cpp
+++ b/src/ompl_global_planner.cpp
@@ -51,7 +51,8 @@
 
 
 //register this planner as a BaseGlobalPlanner plugin
-PLUGINLIB_EXPORT_CLASS(ompl_global_planner::OmplGlobalPlanner, nav_core::BaseGlobalPlanner)
+//PLUGINLIB_EXPORT_CLASS(ompl_global_planner::OmplGlobalPlanner, nav_core::BaseGlobalPlanner)
+PLUGINLIB_DECLARE_CLASS(move_base_ompl, OmplGlobalPlanner, ompl_global_planner::OmplGlobalPlanner, nav_core::BaseGlobalPlanner);
 
 namespace ompl_global_planner
 {


### PR DESCRIPTION
PLUGIN_DECLARE_CLASS used instead of PLUGIN_EXPORT_CLASS solved some of the linking problems in ros indigo